### PR TITLE
Add OAuth URLs as `client_options`

### DIFF
--- a/lib/omniauth/strategies/ravelry.rb
+++ b/lib/omniauth/strategies/ravelry.rb
@@ -4,9 +4,11 @@ module OmniAuth
   module Strategies
     class Ravelry < OmniAuth::Strategies::OAuth
       option :name, 'ravelry'
-      option :client_options, {
-        :site => 'https://api.ravelry.com'
-      }
+      option :client_options,
+             { site:              'https://api.ravelry.com',
+               authorize_url:     'https://www.ravelry.com/oauth/authorize',
+               request_token_url: 'https://www.ravelry.com/oauth/request_token',
+               access_token_url:  'https://www.ravelry.com/oauth/access_token' }
 
       uid{ request.params['username'] }
 

--- a/spec/omniauth/strategies/ravelry_spec.rb
+++ b/spec/omniauth/strategies/ravelry_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe OmniAuth::Strategies::Ravelry do
+  subject :ravelry do
+    OmniAuth::Strategies::Ravelry.new nil, @options || { }
+  end
+
+  describe '#options' do
+    subject(:options) { ravelry.options }
+    describe '#name' do
+      subject { options.name }
+      it { should eq 'ravelry' }
+    end
+    describe '#client_options' do
+      subject(:client_options) { options.client_options }
+      describe '#site' do
+        subject { client_options.site }
+        it { should eq 'https://api.ravelry.com' }
+      end
+    end
+  end
+end

--- a/spec/omniauth/strategies/ravelry_spec.rb
+++ b/spec/omniauth/strategies/ravelry_spec.rb
@@ -17,6 +17,18 @@ describe OmniAuth::Strategies::Ravelry do
         subject { client_options.site }
         it { should eq 'https://api.ravelry.com' }
       end
+      describe '#authorize_url' do
+        subject { client_options.authorize_url }
+        it { should eq 'https://www.ravelry.com/oauth/authorize' }
+      end
+      describe '#request_token_url' do
+        subject { client_options.request_token_url }
+        it { should eq 'https://www.ravelry.com/oauth/request_token' }
+      end
+      describe '#access_token_url' do
+        subject { client_options.access_token_url }
+        it { should eq 'https://www.ravelry.com/oauth/access_token' }
+      end
     end
   end
 end


### PR DESCRIPTION
OAuth URLs for Ravelry are given [here](http://www.ravelry.com/api#authenticating).
Following examples for strategy configuration from [Netflix](https://github.com/stve/omniauth-netflix/blob/master/lib/omniauth/strategies/netflix.rb).

Specs added for options.
